### PR TITLE
Fix for students not being able to re establish sessions after posting images

### DIFF
--- a/src/slack.ts
+++ b/src/slack.ts
@@ -46,8 +46,6 @@ class SlackController {
       
       if (message.thread_ts) {
 
-        console.log(message);
-
         const userInfo = await this.app.client.users.info({
           user: message.user,
           token: context.botToken
@@ -94,7 +92,12 @@ class SlackController {
       initial_comment: `*${username}*: ${text}`,
       file: image
     }) as FilesUploadResult;
-
+    
+    await this.app.client.files.sharedPublicURL({
+      file: response.file.id,
+      token: SLACK_USER_TOKEN
+    }) as FilesSharedPublicURLResult;
+    
     response.ts = response.file.shares.public[channel][0].ts;
 
     return response.file.shares.public[channel][0].ts;;
@@ -233,6 +236,7 @@ interface ChatPostMessageResult extends WebAPICallResult {
 
 interface FilesUploadResult extends WebAPICallResult {
   file: {
+    id: string;
     shares: {
       public: {
         [key: string]: {

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -96,7 +96,7 @@ class SlackController {
     await this.app.client.files.sharedPublicURL({
       file: response.file.id,
       token: SLACK_USER_TOKEN
-    }) as FilesSharedPublicURLResult;
+    });
     
     response.ts = response.file.shares.public[channel][0].ts;
 


### PR DESCRIPTION
Problemet var att bilderna aldrig gjordes publika (så det går att komma åt dem utanför slack) så reestablish_session kraschade när den inte kunde nå urlen för bilderna. 